### PR TITLE
allow usage inside a vite project

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ import withSolid from "rollup-preset-solid";
 export default withSolid();
 ```
 
+In case you want to use rollup-preset-solid inside an existing vite project, you need to use in your vite config:
+
+```js
+// vite.config.js
+import withSolid from "rollup-preset-solid";
+import { defineConfig } from 'vite';
+import solidPlugin from 'vite-plugin-solid';
+
+export default defineConfig({
+  plugins: [solidPlugin()],
+  build: {
+    rollupOptions: withSolid()
+  }
+});
+```
+
+In this case, the index.html can include its dependencies also from a different location than the library, so the entry point for the build differs from the dev view.
+
 3. Configure your package.json
 
 ```json

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "files": [
     "dist"
   ],
+  "type": "module",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {


### PR DESCRIPTION
I tried to include this into our basic vite+ts starter. It worked after setting "type" to "module" in package.json because otherwise the import statements will fail. I also documented the procedere in the README.md.

To use this in the library starter, you also need to adapt the tsconfig:

```js
{
  "compilerOptions": {
    "strict": true,
    "target": "ESNext",
    "module": "ESNext",
    "lib": ["DOM", "DOM.Iterable", "ESNext"],
    "moduleResolution": "node",
    "allowSyntheticDefaultImports": true,
    "resolveJsonModule": true,
    "esModuleInterop": true,
    "jsx": "preserve",
    "jsxImportSource": "solid-js",
    "isolatedModules": true,
    "skipLibCheck": true,
    "types": [],
    "baseUrl": ".",
    "outDir": "dist/solid"
  },
  "include": ["src"],
  "exclude": ["node_modules", "dist"]
}
```

and then you can use the following build script to get the full output:

```js
{
  "build": "vite build; tsc; tsc --sourceMap --outDir dist/types --declaration --emitDeclarationOnly"
}
```
