### PR TITLE
Allow additional TypeScript compiler options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ function processOptions(options: Options, asSubPackage = true): RollupOptions {
     babelOptions,
     solidOptions,
     mappingName,
+    tsCompilerOptions,
     ...rollupOptions
   } = options;
   const currentDir = process.cwd();
@@ -115,6 +116,7 @@ function processOptions(options: Options, asSubPackage = true): RollupOptions {
             declarationDir: asSubPackage ? `dist/${name}` : `dist/types`,
             declaration: true,
             allowJs: true,
+            ...tsCompilerOptions
           });
 
           program.emit();
@@ -260,6 +262,10 @@ export interface Options extends RollupOptions {
    * TODO: Document this
    */
   mappingName?: string;
+  /**
+   * Additional TypeScript compiler options
+   */
+  tsCompilerOptions?: ts.CompilerOptions;
 }
 
 interface SolidOptions {


### PR DESCRIPTION
This PR introduces a new config option for passing additional values to the TypeScript compiler. I'm making use of this myself as in my situation I need to enable the `declarationMap` setting, however I figured this would be a nice flexible addition to the preset.